### PR TITLE
[tests] Add more Node versions to Travis matrix; add CircleCI 2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node
+    steps:
+      - checkout
+      - run: yarn
+      - run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
   - stable
+  - 8
+  - 6
   - 4

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-machine:
-  node:
-    version: node
-
-dependencies:
-  pre:
-    - npm prune
-

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "build": "babel -d build --ignore /__tests__/ src",
+    "prepare": "babel -d build --ignore /__tests__/ src",
     "test": "jest src"
   },
   "babel": {
@@ -30,7 +30,7 @@
     "promise",
     "process"
   ],
-  "author": "support@expo.io",
+  "author": "Expo",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/expo/spawn-async/issues"


### PR DESCRIPTION
Tests Node 6 and 8 on Travis now and adds a config file for CircleCI 2. 