### PR TITLE
[node][breaking] Target Node 8 LTS and up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - stable
+  - 10
   - 8
-  - 6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spawn-async [![CircleCI](https://circleci.com/gh/expo/spawn-async.svg?style=svg)](https://circleci.com/gh/expo/spawn-async) [![Build Status](https://travis-ci.org/expo/spawn-async.svg?branch=master)](https://travis-ci.org/expo/spawn-async)
 
-A cross-platform version of Node's `child_process.spawn` as an async function that returns a promise.
+A cross-platform version of Node's `child_process.spawn` as an async function that returns a promise. Supports Node 8 LTS and up.
 
 ## Usage:
 ```js

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["es2015"],
+    "target": "es2018",
+    "lib": ["es2018"],
     "module": "commonjs",
     "esModuleInterop": true,
     "sourceMap": true,


### PR DESCRIPTION
Adds a note to the README saying Node 8 LTS (8.9.0+) and newer are supported. Updated the tsconfig.json settings so that it targets ES2018, which Node 8.9.0+ supports.

Closes #10