### PR TITLE
[signals][breaking] Reject the promise when the process exits due to a signal w/out code 0

### DIFF
--- a/src/__tests__/spawnAsync-test.ts
+++ b/src/__tests__/spawnAsync-test.ts
@@ -29,12 +29,17 @@ describe('spawnAsync', () => {
     expect(didThrow).toBe(true);
   });
 
-  // NOTE: in a breaking change, signals should probably be treated like non-zero exit codes
-  it(`returns when processes are killed with signals`, async () => {
-    let result = await spawnAsync(path.join(__dirname, 'signal-self.sh'));
-    expect(typeof result.pid).toBe('number');
-    expect(result.status).toBe(null);
-    expect(result.signal).toBe('SIGKILL');
+  it(`returns when processes are killed with signals with non-zero exit codes`, async () => {
+    let didThrow = false;
+    try {
+      await spawnAsync(path.join(__dirname, 'signal-self.sh'));
+    } catch (e) {
+      didThrow = true;
+      expect(typeof e.pid).toBe('number');
+      expect(e.status).toBe(null);
+      expect(e.signal).toBe('SIGKILL');
+    }
+    expect(didThrow).toBe(true);
   });
 
   it(`throws errors when processes don't exist`, async () => {

--- a/src/spawnAsync.ts
+++ b/src/spawnAsync.ts
@@ -48,8 +48,10 @@ export = function spawnAsync(
         status: code,
         signal,
       };
-      if (code) {
-        let error = new Error(`Process exited with non-zero code: ${code}`);
+      if (code !== 0) {
+        let error = signal
+          ? new Error(`Process exited with signal: ${signal}`)
+          : new Error(`Process exited with non-zero code: ${code}`);
         Object.assign(error, result);
         reject(error);
       } else {


### PR DESCRIPTION
When a process exits because of a signal like SIGKILL, SIGTERM, or SIGINT, this makes `spawnAsync` reject the promise (i.e. throw an async error) instead of returning normally. This is because the process did not exit with code 0 -- Node sets the code to `null` and specifies the signal instead.

Test plan: Updated unit test to check for this case using a small program that kills itself using a signal.

Closes #9