### PR TITLE
[ts] Change `export =` to `export default` and export type definitions

### DIFF
--- a/src/__tests__/spawnAsync-test.ts
+++ b/src/__tests__/spawnAsync-test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import spawnAsync from '../spawnAsync';
+import spawnAsync, { SpawnPromise, SpawnResult } from '../spawnAsync';
 
 describe('spawnAsync', () => {
   it(`receives output from completed processes`, async () => {
@@ -52,7 +52,8 @@ describe('spawnAsync', () => {
   });
 
   it(`exposes the child process through a property named "child"`, async () => {
-    let spawnTask = spawnAsync('echo', ['hi']);
+    // The type hint isn't necessary but tests that the types are exported and work as expected
+    let spawnTask: SpawnPromise<SpawnResult> = spawnAsync('echo', ['hi']);
     let childProcess = spawnTask.child;
     expect(childProcess).toBeDefined();
 

--- a/src/spawnAsync.ts
+++ b/src/spawnAsync.ts
@@ -1,11 +1,11 @@
 import { ChildProcess, SpawnOptions } from 'child_process';
 import spawn from 'cross-spawn';
 
-interface SpawnPromise<T> extends Promise<T> {
+export interface SpawnPromise<T> extends Promise<T> {
   child: ChildProcess;
 }
 
-interface SpawnResult {
+export interface SpawnResult {
   pid: number;
   output: string[];
   stdout: string;
@@ -14,7 +14,7 @@ interface SpawnResult {
   signal: string | null;
 }
 
-export = function spawnAsync(
+export default function spawnAsync(
   command: string,
   args?: ReadonlyArray<string>,
   options?: SpawnOptions


### PR DESCRIPTION
This makes it possible to declare the types of variables where you might want to store the spawn promise. For example:

```js
import spawnAsync, { SpawnPromise, SpawnResult } from '@expo/spawn-async';

class Example {
  spawnTask: SpawnPromise<SpawnResult> | null = null;

  ...

  method1() {
    this.spawnTask = spawnAsync(...);
    this.spawnTask.child...
  }

  async method2() {
    let result: SpawnResult | null = null;
    try {
      result = await this.spawnTask!;
    } finally {
      this.spawnTask = null;
    }
    ...
  }
}
```

Test plan: Added types to a unit test to verify they work as expected.

Closes #8