### PR TITLE
[exit] Add "ignoreStdio" option to listen to the "exit" event instead of "close"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ import spawnAsync from '@expo/spawn-async';
 
 ## API
 
-`spawnAsync` takes the same arguments as [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).
+`spawnAsync` takes the same arguments as [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options). Its options are the same as those of `child_process.spawn` plus:
+
+- `ignoreStdio`: whether to ignore waiting for the child process's stdio streams to close before resolving the result promise. When ignoring stdio, the returned values for `stdout` and `stderr` will be empty strings. The default value of this option is `false`.
 
 It returns a promise whose result is an object with these properties:
 


### PR DESCRIPTION
When a subprocess exits, Node will fire the "exit" event even if the subprocess's stdio streams are open. Usually this doesn't matter as the "close" event is fired soon after, but in some cases -- especially when sharing or piping I/O streams -- the streams may stay open after a subprocess exits.

To listen to the "exit" event, this commit introduces a new option named `ignoreStdio`. It is named this way because it does not wait for the stdio streams to close and also does not read data from them. This is a deliberate decision since a very small fraction of the time, the "exit" event may fire before we can collect all data from stdout. This would be very hard to debug and non-deterministic, so when listening to the "exit" event we never read from stdout/stderr and just return empty strings.

Test plan: Added a test that hangs when `ignoreStdio` is false/omitted that verifies the promise resolves even if stdout is open.

Closes #3.