### PR TITLE
Make errors more useful

### DIFF
--- a/src/__tests__/spawnAsync-test.ts
+++ b/src/__tests__/spawnAsync-test.ts
@@ -120,3 +120,13 @@ it(`returns even if stdout is open when ignoring stdio`, async () => {
   sinkTask.child.stdin.destroy();
   await expect(sinkTask).resolves.toMatchObject({ status: 0, stdout: '', stderr: '' });
 });
+
+it('throws errors with preserved stack traces when processes return non-zero exit codes', async () => {
+  expect.assertions(2);
+  try {
+    await spawnAsync('false');
+  } catch (e) {
+    expect(e.stack).toMatch(/\n    \.\.\.\n/);
+    expect(e.stack).toMatch(/at Object\.spawnAsync/);
+  }
+});

--- a/src/spawnAsync.ts
+++ b/src/spawnAsync.ts
@@ -57,8 +57,8 @@ export = function spawnAsync(
       };
       if (code !== 0) {
         let error = signal
-          ? new Error(`Process exited with signal: ${signal}`)
-          : new Error(`Process exited with non-zero code: ${code}`);
+          ? new Error(`${command} exited with signal: ${signal}`)
+          : new Error(`${command} exited with non-zero code: ${code}`);
         Object.assign(error, result);
         reject(error);
       } else {

--- a/src/spawnAsync.ts
+++ b/src/spawnAsync.ts
@@ -23,6 +23,10 @@ export = function spawnAsync(
   args?: ReadonlyArray<string>,
   options: SpawnOptions = {}
 ): SpawnPromise<SpawnResult> {
+  const fakeErr = new Error('fake error just to preserve stacktrace');
+  const previousStack = fakeErr.stack && fakeErr.stack.split('\n').splice(1);
+  const previousStackString = previousStack && ['    ...', ...previousStack].join('\n');
+
   let child: ChildProcess;
   let promise = new Promise((resolve, reject) => {
     let { ignoreStdio, ...nodeOptions } = options;
@@ -59,6 +63,9 @@ export = function spawnAsync(
         let error = signal
           ? new Error(`${command} exited with signal: ${signal}`)
           : new Error(`${command} exited with non-zero code: ${code}`);
+        if (error.stack && previousStackString) {
+          error.stack += `\n${previousStackString}`
+        }
         Object.assign(error, result);
         reject(error);
       } else {


### PR DESCRIPTION
# Why

If an executed command fails, we don't provide helpful information about the origin of the error. If we use spawnAsync in a few different places in our code we cannot be sure which command failed just by looking at the error stack trace.

This is particularly annoying when people post issues which they experience with turtle-cli. The most recent example of this is - https://github.com/expo/turtle/issues/45 - all that user posted is `err: Error: Process exited with non-zero code: 1` which doesn't say anything. Of course, he could've posted more logs (including few more lines before) but people tend not to do it.

# How

- I added command name to the error message.
- I added a little hack to preserve the real stack trace (which we lose because of the asynchronous nature of this function).

# Test Plan

I tested this locally. I had two files:

`a.sh`:
```bash
#!/usr/bin/env bash

echo $@

exit 1
```

`test.ts`:
```ts
import spawnAsync from '@expo/spawn-async';

async function main() {
  const x = await spawnAsync('./a.sh', ['this', 'is', 'a', 'test']);
  console.log(x);
}


main()
  .then(() => console.log('done'))
  .catch(err => console.error(err));
```

This is what I got after running the script:
```
$ ts-node test.ts
{ Error: ./a.sh exited with non-zero code: 1
    at ChildProcess.completionListener (/Users/dsokal/workspace/expo/spawn-async/build/spawnAsync.js:51:23)                                                                                                
    at Object.onceWrapper (events.js:317:30)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:915:16)
    at Socket.stream.socket.on (internal/child_process.js:336:11)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at Pipe._handle.close [as _onclose] (net.js:561:12)
    ...
    at Object.spawnAsync [as default] (/Users/dsokal/workspace/expo/spawn-async/build/spawnAsync.js:16:21)                                                                                                 
    at main (/Users/dsokal/workspace/xyz/test.ts:4:29)
    at Object.<anonymous> (/Users/dsokal/workspace/xyz/test.ts:9:1)
    at Module._compile (module.js:653:30)
    at Module.m._compile (/Users/dsokal/workspace/xyz/node_modules/ts-node/src/index.ts:439:23)
    at Module._extensions..js (module.js:664:10)
    at Object.require.extensions.(anonymous function) [as .ts] (/Users/dsokal/workspace/xyz/node_modules/ts-node/src/index.ts:442:12)                                                                      
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
  pid: 2826,
  output: [ 'this is a test\n', '' ],
  stdout: 'this is a test\n',
  stderr: '',
  status: 1,
  signal: null }
```