### PR TITLE
Add CJS entry point and typings to package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./build/spawnAsync').default;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.2",
   "description": "A Promise-based interface into processes created by child_process.spawn",
   "main": "index.js",
-  "typings": "./build/spawnAsync.d.ts",
+  "types": "./build/spawnAsync.d.ts",
   "files": [
     "build"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@expo/spawn-async",
   "version": "1.4.2",
   "description": "A Promise-based interface into processes created by child_process.spawn",
-  "main": "build/spawnAsync.js",
+  "main": "index.js",
+  "typings": "./build/spawnAsync.d.ts",
   "files": [
     "build"
   ],


### PR DESCRIPTION
This PR adds an `index.js` entry point, which just re-exports the `default` export from `build/spawnAsync.js`. This way the package can be imported when using bundlers that support ESM and also when using `require('@expo/spawn-async')` in Node.

Additionally a `typings` field is added to `package.json` so that TypeScript can find the type definition.

Fixes #8.