### PR TITLE
Use TS export assignment for better ESM/CJS compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./build/spawnAsync').default;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@expo/spawn-async",
   "version": "1.6.0",
   "description": "A Promise-based interface into processes created by child_process.spawn",
-  "main": "index.js",
+  "main": "./build/spawnAsync.js",
   "types": "./build/spawnAsync.d.ts",
   "files": [
     "build"

--- a/src/__tests__/spawnAsync-test.ts
+++ b/src/__tests__/spawnAsync-test.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import path from 'path';
 
-import spawnAsync from '../spawnAsync';
+import spawnAsync, { SpawnOptions, SpawnPromise, SpawnResult } from '../spawnAsync';
 
 it(`receives output from completed processes`, async () => {
   let result = await spawnAsync('echo', ['hi']);
@@ -132,3 +132,10 @@ it('throws errors with preserved stack traces when processes return non-zero exi
     expect(e.stack).toMatch(/at spawnAsync/);
   }
 });
+
+it(`exports TypeScript types`, async () => {
+  let options: SpawnOptions = {};
+  let promise: SpawnPromise<SpawnResult> = spawnAsync('echo', ['hi'], options);
+  let result: SpawnResult = await promise;
+  expect(typeof result.pid).toBe('number');
+})


### PR DESCRIPTION
Why
---
Fixes #37 

Using `export =` is a good way to make TS emit code that works with both CJS and ESM as long as the consumer uses `esModuleInterop: true`.

How
---
Needed to use namespace merging so that the spawnAsync function could be the assigned export (`export =` allows only one thing to be exported from the entire file).

Removed `index.js` since we can import from the TS file directly.

Test Plan
---
- Types: Added TypeScript imports to the Jest test file, where types are checked.
- CJS: Unit test verifies that CJS imports work. Tested end-to-end:
```
npm pack
cd /tmp
mkdir test
cd test
npm init
yarn add <path to packed tgz>
node
await require('@expo/spawn-async')('echo', ['hi'])
```