### PR TITLE
Show the args that caused the error

### DIFF
--- a/src/spawnAsync.ts
+++ b/src/spawnAsync.ts
@@ -62,8 +62,8 @@ function spawnAsync(
       };
       if (code !== 0) {
         let error = signal
-          ? new Error(`${command} exited with signal: ${signal}`)
-          : new Error(`${command} exited with non-zero code: ${code}`);
+          ? new Error(`${command} ${args.join(" ")} exited with signal: ${signal}`)
+          : new Error(`${command} ${args.join(" ")} exited with non-zero code: ${code}`);
         if (error.stack && callerStack) {
           error.stack += `\n${callerStack}`;
         }


### PR DESCRIPTION
Since the error only shows `npx` failed which is generally useless since it does not tell us what the actual node module was being called

This may leak sensitive information