### PR TITLE
Fix formatting of error message, add regression test

### DIFF
--- a/src/__tests__/spawnAsync-test.ts
+++ b/src/__tests__/spawnAsync-test.ts
@@ -22,11 +22,16 @@ it(`throws errors when processes return non-zero exit codes`, async () => {
     await spawnAsync('false');
   } catch (e: any) {
     didThrow = true;
+    expect(e.message).toBe(`false exited with non-zero code: 1`);
     expect(typeof e.pid).toBe('number');
     expect(e.status).toBe(1);
     expect(e.signal).toBe(null);
   }
   expect(didThrow).toBe(true);
+});
+
+it(`includes command arguments in the error message`, async () => {
+  await expect(() => spawnAsync('false', ['dummy'])).rejects.toThrowError(`false dummy exited`);
 });
 
 it(`returns when processes are killed with signals with non-zero exit codes`, async () => {
@@ -138,4 +143,4 @@ it(`exports TypeScript types`, async () => {
   let promise: SpawnPromise<SpawnResult> = spawnAsync('echo', ['hi'], options);
   let result: SpawnResult = await promise;
   expect(typeof result.pid).toBe('number');
-})
+});

--- a/src/spawnAsync.ts
+++ b/src/spawnAsync.ts
@@ -61,10 +61,10 @@ function spawnAsync(
         signal,
       };
       if (code !== 0) {
-        let args_ = args ? args.join(" ") : "";
+        let argumentString = args && args.length > 0 ? ` ${args.join(' ')}` : '';
         let error = signal
-          ? new Error(`${command} ${args_} exited with signal: ${signal}`)
-          : new Error(`${command} ${args_} exited with non-zero code: ${code}`);
+          ? new Error(`${command}${argumentString} exited with signal: ${signal}`)
+          : new Error(`${command}${argumentString} exited with non-zero code: ${code}`);
         if (error.stack && callerStack) {
           error.stack += `\n${callerStack}`;
         }


### PR DESCRIPTION
Why: the formatting had an extra space when there were no args.

How: omitted an extra space when the args array is undefined or empty.

Test plan: added regression tests